### PR TITLE
fix: post-PR#41 breakage and lingering 25.11 deprecations

### DIFF
--- a/homes/ank/configs/opencode.nix
+++ b/homes/ank/configs/opencode.nix
@@ -1,7 +1,7 @@
 { pkgs, inputs, ... }:
 let
   jail = inputs.jail-nix.lib.init pkgs;
-  opencode_pkg = inputs.llm-agents.packages.${pkgs.hostPlatform.system}.opencode;
+  opencode_pkg = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.opencode;
   # Common packages available to both agents
   commonPkgs = with pkgs; [
     bashInteractive
@@ -53,7 +53,7 @@ let
 in
 {
   home.packages = [
-    inputs.llm-agents.packages.${pkgs.hostPlatform.system}.agent-deck
+    inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.agent-deck
   ];
   programs.opencode = {
     package = custom_opencode_pkg;

--- a/homes/ank/machines/chiral.nix
+++ b/homes/ank/machines/chiral.nix
@@ -29,7 +29,7 @@
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/wsl/lib
   '';
 
-  programs.git.extraConfig = {
+  programs.git.settings = {
     safe.directory = "*";
   };
 }

--- a/homes/ank/machines/karkinos.nix
+++ b/homes/ank/machines/karkinos.nix
@@ -12,7 +12,7 @@
     ../../common/dev/kalam.nix
     ../../common/themes
     ../configs/opencode.nix
-    ../configs/zsh_alias.nix
+    ../configs/zsh.nix
     (import ../../common/dev/editors.nix {
       inherit pkgs config inputs;
       enableNvim = false;

--- a/homes/ank/machines/oppy.nix
+++ b/homes/ank/machines/oppy.nix
@@ -11,7 +11,7 @@
     ../../common/dev
     ../../common/dev/kalam.nix
     ../../common/themes
-    ../configs/zsh_alias.nix
+    ../configs/zsh.nix
     (import ../../common/dev/editors.nix {
       inherit pkgs config inputs;
       enableNvim = false;

--- a/homes/common/home_manager.nix
+++ b/homes/common/home_manager.nix
@@ -2,6 +2,7 @@
 {
   nixpkgs = {
     overlays = builtins.attrValues outputs.overlays;
+    config.allowUnfree = true;
   };
 
   home.stateVersion = "25.11";

--- a/machines/chiral/default.nix
+++ b/machines/chiral/default.nix
@@ -44,7 +44,7 @@
   # FHS
   programs.nix-ld = {
     enable = true;
-    package = pkgs.nix-ld-rs;
+    package = pkgs.nix-ld;
   };
 
   # NVidia and cuda support


### PR DESCRIPTION
## Summary

Small cleanup PR with two themes:

### Breakage from PR #41

- **Stranded zsh imports**: `aa9e5a7` renamed `homes/ank/configs/zsh_alias.nix` → `zsh.nix` and updated imports in `darwin001.nix` and `rogue.nix`, but missed `oppy.nix` and `karkinos.nix`. Both machines currently fail to evaluate with `path .../zsh_alias.nix does not exist`.
- **home-manager doesn't inherit `allowUnfree`**: `feba0f4` added `claude-code` (unfree) to amunoz's home packages. System-level `nixpkgs.config.allowUnfree = true` in `machines/common/system.nix` doesn't propagate to home-manager's separate nixpkgs context. Fixed by adding `config.allowUnfree = true` to `homes/common/home_manager.nix`, which is where shared home-manager nixpkgs config lives (already sets overlays the same way).

  Note: this is a policy choice as well as a bug fix. A narrower alternative would be `allowUnfreePredicate` scoped to specific package names; happy to switch to that form if preferred.

### Missed 25.11 deprecations in chiral / ank configs

Not caused by PR #41, but `nix flake check` surfaced three deprecations in files the 25.11 sweep didn't touch:

- `machines/chiral/default.nix`: `pkgs.nix-ld-rs` → `pkgs.nix-ld` (the `-rs` suffix was dropped when the Rust impl became the default)
- `homes/ank/machines/chiral.nix`: `programs.git.extraConfig` → `programs.git.settings`
- `homes/ank/configs/opencode.nix`: `pkgs.hostPlatform.system` → `pkgs.stdenv.hostPlatform.system` (two occurrences)

## Test plan

- [x] `nix flake check --keep-going --no-build` → exit 0, no deprecation warnings (oppy, karkinos, chiral all evaluate cleanly)
- [x] `nix build .#nixosConfigurations.oppy.config.system.build.toplevel` → clean
- [x] `sudo nixos-rebuild switch --flake .#oppy` → gen 29 active
- [x] `nix build .#nixosConfigurations.karkinos.config.system.build.toplevel` → clean, verified by SSH to karkinos on this branch
- [ ] Chiral not currently in use, but now at least evaluates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>